### PR TITLE
Final and first draft.

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,6 +19,11 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    public void setTitleAuthor(String newTitle, String newAuthor) {
+        this.title = newTitle;
+        this.author = newAuthor;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +42,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+                //author.equals(theOtherBook.author) &&
+                //title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -18,6 +18,10 @@ public abstract class Movie implements StoreMediaOperations {
         this.title = anotherMovie.title;
         this.id = anotherMovie.id;
     }
+    public void setRatingTitle(String newRating, String newTitle) {
+        this.rating = newRating;
+        this.title = newTitle;
+    }
 
     @Override
     public boolean equals(Object obj) {
@@ -37,11 +41,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+        //        rating.equals(theOtherMovie.rating) &&
+        //        title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -6,12 +6,18 @@ import static org.junit.Assert.*;
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
-        // quiz
+        BookFiction b = new BookFiction("Harry Potter and the CS class", "Tim Medvedev", "Fantasy");
+        BookFiction bc = new BookFiction(b);
+        bc.setTitleAuthor("A Song of Getters and Setters", "George RR Martin");
+        assertTrue(b.equals(bc));
     }
 
     @Test
     public void catchTheBugInMovie() {
-        // quiz
+        MovieAction m = new MovieAction("PG13", "ti1");
+        MovieAction mc = new MovieAction(m);
+        mc.setRatingTitle("PG", "ti2");
+        assertTrue(m.equals(mc));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The tests were passing since the tests were all using assertFalse(movie 1 equals (movie2)) , this was returning a pass as equals did return false as the ID's did not match even if the title and rating or author were different. The instructions for the assignment specifically said that two movies or books were only to be determined as equal if the ID of the two books/movies was the same. The old tests would pass as equals would return false if two books/movies had the same exact UUID but different string values. This is not correct, the ID must be the deciding factor on whether the two objects were equal or not.